### PR TITLE
Remove _src metadata from parse_pdf output

### DIFF
--- a/tickets_parser.py
+++ b/tickets_parser.py
@@ -236,7 +236,7 @@ def parse_header_block(cleaned: str, lines: List[str]) -> Dict[str,str]:
 def parse_pdf(pdf_path: str, tz: ZoneInfo, now: datetime) -> Dict[str,str]:
     raw = extract_text(pdf_path)
     if not raw or len(raw) < 80:
-        return {"N° Ticket":"","Título del ticket":"","Estado":"","Prioridad":"","Departamento":"","Fecha de creación":"","Última respuesta por":"","Última respuesta el":"","Error":"no_text_extracted","_src":os.path.basename(pdf_path)}
+        return {"N° Ticket":"","Título del ticket":"","Estado":"","Prioridad":"","Departamento":"","Fecha de creación":"","Última respuesta por":"","Última respuesta el":"","Error":"no_text_extracted"}
     cleaned = clean_text(raw)
     lines = cleaned.splitlines()
     hdr = parse_header_block(cleaned, lines)
@@ -260,8 +260,7 @@ def parse_pdf(pdf_path: str, tz: ZoneInfo, now: datetime) -> Dict[str,str]:
         "Fecha de creación": hdr.get("Create Date",""),
         "Última respuesta por": last_by,
         "Última respuesta el": last_at,
-        "Error": "",
-        "_src": os.path.basename(pdf_path)
+        "Error": ""
     }
 
 def main():


### PR DESCRIPTION
## Summary
- stop `tickets_parser.parse_pdf` from adding the `_src` key in both success and fallback branches so downstream code no longer expects that metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cab25a37c48320b6535f3c7af408b9