### PR TITLE
Rename Estado column and enforce Excel ordering

### DIFF
--- a/tests/test_excel_columns.py
+++ b/tests/test_excel_columns.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+import openpyxl
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import tickets_parser
+
+
+def test_generated_excel_has_expected_columns(tmp_path, monkeypatch):
+    output_path = tmp_path / "Tickets.xlsx"
+    dummy_pdf = tmp_path / "Ticket-0001.pdf"
+    dummy_pdf.write_bytes(b"")
+
+    monkeypatch.setattr(tickets_parser, "glob", lambda pattern: [str(dummy_pdf)])
+
+    def fake_parse_pdf(path, tz, now):
+        return {
+            "N° Ticket": "123",
+            "Título del ticket": "Prueba",
+            "Estado BW": "Abierto",
+            "Prioridad": "Alta",
+            "Departamento": "IT",
+            "Fecha de creación": "",
+            "Autor": "Alice",
+            "Última respuesta por": "Bob",
+            "Última respuesta el": "",
+            "Error": "",
+        }
+
+    monkeypatch.setattr(tickets_parser, "parse_pdf", fake_parse_pdf)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tickets_parser.py",
+            "--pdf_dir",
+            str(tmp_path),
+            "--out",
+            str(output_path),
+        ],
+    )
+
+    tickets_parser.main()
+
+    workbook = openpyxl.load_workbook(output_path)
+    worksheet = workbook["Tickets"]
+    header_row = next(worksheet.iter_rows(min_row=1, max_row=1, values_only=True))
+
+    expected_order = [
+        "N Ticket",
+        "Título del ticket",
+        "Autor",
+        "Estado BW",
+        "Prioridad",
+        "Área",
+        "Departamento",
+    ]
+
+    assert header_row[: len(expected_order)] == tuple(expected_order)
+    assert "Estado BW" in header_row

--- a/tests/test_parse_pdf_timestamp.py
+++ b/tests/test_parse_pdf_timestamp.py
@@ -1,16 +1,10 @@
 from datetime import datetime
 from pathlib import Path
 import sys
-import types
 
 from zoneinfo import ZoneInfo
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-pd_stub = types.ModuleType("pandas")
-pd_stub.DataFrame = lambda *args, **kwargs: None
-pd_stub.to_excel = lambda *args, **kwargs: None
-sys.modules.setdefault("pandas", pd_stub)
 
 from tickets_parser import parse_pdf_timestamp
 


### PR DESCRIPTION
## Summary
- rename the parse_pdf output to expose the Estado BW column
- normalize the DataFrame to rename N° Ticket and enforce the requested column order
- add regression coverage that inspects the generated Excel headers and allow tests to import the real module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cacd2c86f08320864e48364ec8c1ad