### PR TITLE
Remove Estado BW column from Excel output

### DIFF
--- a/tests/test_excel_columns.py
+++ b/tests/test_excel_columns.py
@@ -52,11 +52,9 @@ def test_generated_excel_has_expected_columns(tmp_path, monkeypatch):
         "N Ticket",
         "Título del ticket",
         "Autor",
-        "Estado BW",
         "Prioridad",
         "Área",
         "Departamento",
     ]
 
     assert header_row[: len(expected_order)] == tuple(expected_order)
-    assert "Estado BW" in header_row

--- a/tickets_parser.py
+++ b/tickets_parser.py
@@ -326,6 +326,11 @@ def main():
     if rename_map:
         df = df.rename(columns=rename_map)
 
+    estado_bw_series = None
+    if "Estado BW" in df.columns:
+        estado_bw_series = df["Estado BW"].copy()
+        df = df.drop(columns=["Estado BW"])
+
     if "Área" not in df.columns:
         df["Área"] = ""
     else:
@@ -353,7 +358,6 @@ def main():
         "N Ticket",
         "Título del ticket",
         "Autor",
-        "Estado BW",
         "Prioridad",
         "Área",
         "Departamento",
@@ -379,7 +383,9 @@ def main():
     df["Tiempo parado desde la última respuesta"] = df["Última respuesta el"].apply(lambda s: human_delta((now - parse_date(s)).total_seconds() if parse_date(s) else None))
 
     def compute_open_age(row):
-        st = row.get("Estado BW","")
+        st = ""
+        if estado_bw_series is not None:
+            st = estado_bw_series.get(row.name, "")
         cd = parse_date(row.get("Fecha de creación",""))
         if cd and is_open_status(st):
             return human_delta((now - cd).total_seconds())


### PR DESCRIPTION
## Summary
- drop the Estado BW column from the exported Excel while retaining its values for internal calculations
- update the open-age computation to read the stored state values before the column is removed
- adjust the Excel header test to reflect the new column order without Estado BW

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae43ea2708320be840776a0229b34