### PR TITLE
Ensure ticket headers populate mandatory fields

### DIFF
--- a/tests/test_excel_columns.py
+++ b/tests/test_excel_columns.py
@@ -26,7 +26,6 @@ def test_generated_excel_has_expected_columns(tmp_path, monkeypatch):
             "Autor": "Alice",
             "Última respuesta por": "Bob",
             "Última respuesta el": "",
-            "Error": "",
         }
 
     monkeypatch.setattr(tickets_parser, "parse_pdf", fake_parse_pdf)


### PR DESCRIPTION
## Summary
- add resilient ticket header parsing helpers so number, status, priority and creation date are extracted from every PDF
- remove the unused Error column and propagate trimmed header values while keeping department blank when the area is unset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae7e28dcc83208e42167385a50ece