### PR TITLE
Ensure ticket exports use native datetime and duration types

### DIFF
--- a/tickets_parser.py
+++ b/tickets_parser.py
@@ -556,31 +556,59 @@ def main():
 
     df = df.fillna("")
 
-    def human_delta(td_seconds: Optional[float]) -> str:
-        if td_seconds is None: return ""
-        secs = int(td_seconds)
-        if secs <= 0: return ""
-        mins, _ = divmod(secs, 60)
-        hrs, m = divmod(mins, 60)
-        days, h = divmod(hrs, 24)
-        if days > 0: return f"{days}d {h}h"
-        if hrs > 0: return f"{hrs}h {m}m"
-        return f"{m}m"
+    def to_local_naive_timestamp(value) -> pd.Timestamp:
+        dt: Optional[datetime] = None
+        if isinstance(value, pd.Timestamp):
+            dt = value.to_pydatetime()
+        elif isinstance(value, datetime):
+            dt = value
+        elif isinstance(value, str) and value.strip():
+            dt = parse_pdf_timestamp(value, now, tz)
+        if dt is None:
+            return pd.NaT  # type: ignore[return-value]
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=tz)
+        else:
+            dt = dt.astimezone(tz)
+        return pd.Timestamp(dt.replace(tzinfo=None))
 
-    def parse_date(s: str) -> Optional[datetime]:
-        return parse_pdf_timestamp(s, now, tz)
+    datetime_columns = [
+        col for col in ("Fecha de creación", "Última respuesta el") if col in df.columns
+    ]
+    for col in datetime_columns:
+        df[col] = df[col].apply(to_local_naive_timestamp)
 
-    df["Tiempo parado desde la última respuesta"] = df["Última respuesta el"].apply(lambda s: human_delta((now - parse_date(s)).total_seconds() if parse_date(s) else None))
+    now_local = now.replace(tzinfo=None)
+    now_timestamp = pd.Timestamp(now_local)
+    zero_delta = pd.Timedelta(0)
 
-    def compute_open_age(row):
-        st = ""
+    if "Última respuesta el" in df.columns:
+        last_response_series = df["Última respuesta el"]
+        wait_deltas = now_timestamp - last_response_series
+        wait_deltas = wait_deltas.where(last_response_series.notna(), pd.NaT)
+        wait_deltas = wait_deltas.where(wait_deltas > zero_delta, pd.NaT)
+        df["Tiempo parado desde la última respuesta"] = wait_deltas
+
+    if "Fecha de creación" in df.columns:
+        creation_series = df["Fecha de creación"]
+        open_status_mask = pd.Series(True, index=df.index)
         if estado_bw_series is not None:
-            st = estado_bw_series.get(row.name, "")
-        cd = parse_date(row.get("Fecha de creación",""))
-        if cd and is_open_status(st):
-            return human_delta((now - cd).total_seconds())
-        return ""
-    df["Tiempo abierto (si sigue abierto)"] = df.apply(compute_open_age, axis=1)
+            open_status_mask = estado_bw_series.apply(is_open_status)
+            open_status_mask = open_status_mask.reindex(df.index, fill_value=True)
+        open_deltas = now_timestamp - creation_series
+        open_deltas = open_deltas.where(creation_series.notna(), pd.NaT)
+        open_deltas = open_deltas.where(open_status_mask, pd.NaT)
+        open_deltas = open_deltas.where(open_deltas > zero_delta, pd.NaT)
+        df["Tiempo abierto (si sigue abierto)"] = open_deltas
+
+    duration_columns = [
+        col
+        for col in (
+            "Tiempo parado desde la última respuesta",
+            "Tiempo abierto (si sigue abierto)",
+        )
+        if col in df.columns
+    ]
 
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
 
@@ -607,6 +635,22 @@ def main():
         priority_range = f"{priority_col}{data_row_start}:{priority_col}{data_row_end}"
         area_range = f"{area_col}{data_row_start}:{area_col}{data_row_end}"
         dept_range = f"{dept_col}{data_row_start}:{dept_col}{data_row_end}"
+
+        last_data_row = len(df) + 1
+        date_number_format = "yyyy-mm-dd hh:mm:ss"
+        duration_number_format = "[h]:mm:ss"
+
+        for col_name in datetime_columns:
+            col_idx = df.columns.get_loc(col_name) + 1
+            col_letter = get_column_letter(col_idx)
+            for row_idx in range(data_row_start, last_data_row + 1):
+                ws[f"{col_letter}{row_idx}"].number_format = date_number_format
+
+        for col_name in duration_columns:
+            col_idx = df.columns.get_loc(col_name) + 1
+            col_letter = get_column_letter(col_idx)
+            for row_idx in range(data_row_start, last_data_row + 1):
+                ws[f"{col_letter}{row_idx}"].number_format = duration_number_format
 
         priority_formula = '"' + ",".join(PRIORITY_OPTIONS) + '"'
         dv_priority = DataValidation(type="list", formula1=priority_formula, allow_blank=True)


### PR DESCRIPTION
## Summary
- convert ticket date columns to timezone-normalized datetime values and compute wait/open durations as timedeltas
- apply Excel number formats so Power BI reads the exported dates and durations as native types
- add a regression test that checks the written Excel file stores datetimes and durations using the expected formats

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb092afb688320be5b583ed0491b31