### PR TITLE
Export durations as HH:MM:SS text with numeric seconds columns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openpyxl>=3.1.5
+pandas>=2.2.3
+PyPDF2>=3.0.1

--- a/tests/test_excel_columns.py
+++ b/tests/test_excel_columns.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 import sys
 
 import openpyxl
 from openpyxl.utils import get_column_letter
+import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import tickets_parser
@@ -253,23 +254,43 @@ def test_dates_and_durations_are_written_with_native_types(tmp_path, monkeypatch
     last_response_idx = headers.index("Última respuesta el") + 1
     wait_idx = headers.index("Tiempo parado desde la última respuesta") + 1
     open_idx = headers.index("Tiempo abierto (si sigue abierto)") + 1
+    wait_seconds_idx = (
+        headers.index("Tiempo parado desde la última respuesta (segundos)") + 1
+    )
+    open_seconds_idx = (
+        headers.index("Tiempo abierto (si sigue abierto) (segundos)") + 1
+    )
 
     creation_cell = worksheet.cell(row=2, column=creation_idx)
     last_response_cell = worksheet.cell(row=2, column=last_response_idx)
     wait_cell = worksheet.cell(row=2, column=wait_idx)
     open_cell = worksheet.cell(row=2, column=open_idx)
+    wait_seconds_cell = worksheet.cell(row=2, column=wait_seconds_idx)
+    open_seconds_cell = worksheet.cell(row=2, column=open_seconds_idx)
 
     assert isinstance(creation_cell.value, datetime)
     assert isinstance(last_response_cell.value, datetime)
     assert creation_cell.number_format == "yyyy-mm-dd hh:mm:ss"
     assert last_response_cell.number_format == "yyyy-mm-dd hh:mm:ss"
 
-    assert isinstance(wait_cell.value, timedelta)
-    assert isinstance(open_cell.value, timedelta)
-    assert wait_cell.number_format == "[h]:mm:ss"
-    assert open_cell.number_format == "[h]:mm:ss"
+    assert isinstance(wait_cell.value, str)
+    assert isinstance(open_cell.value, str)
+    assert wait_cell.value == "02:30:00"
+    assert open_cell.value == "28:00:00"
+    assert wait_cell.number_format == "@"
+    assert open_cell.number_format == "@"
 
-    assert wait_cell.value.total_seconds() == 2.5 * 3600
-    assert open_cell.value == timedelta(days=1, hours=4)
+    assert isinstance(wait_seconds_cell.value, (int, float))
+    assert isinstance(open_seconds_cell.value, (int, float))
+    assert wait_seconds_cell.number_format == "0"
+    assert open_seconds_cell.number_format == "0"
+
+    assert "1899" not in wait_cell.value
+    assert "1899" not in open_cell.value
+    assert "/" not in wait_cell.value
+    assert "/" not in open_cell.value
+
+    assert wait_seconds_cell.value == pytest.approx(2 * 3600 + 30 * 60)
+    assert open_seconds_cell.value == pytest.approx(28 * 3600)
 
     workbook.close()

--- a/tickets_parser.py
+++ b/tickets_parser.py
@@ -651,6 +651,50 @@ def main():
         if col in df.columns
     ]
 
+    def timedelta_to_total_seconds(value):
+        if pd.isna(value):
+            return None
+        if isinstance(value, pd.Timedelta):
+            delta = value.to_pytimedelta()
+        elif isinstance(value, timedelta):
+            delta = value
+        else:
+            return None
+        total_seconds = delta.total_seconds()
+        if total_seconds < 0:
+            return None
+        return int(round(total_seconds))
+
+    duration_seconds_suffix = " (segundos)"
+    duration_seconds_values = {}
+    duration_display_values = {}
+    for col in duration_columns:
+        original_values = list(df[col])
+        seconds_values = [
+            timedelta_to_total_seconds(value)
+            for value in original_values
+        ]
+        display_values = []
+        for seconds_value in seconds_values:
+            if seconds_value is None:
+                display_values.append("")
+            else:
+                hours, remainder = divmod(int(seconds_value), 3600)
+                minutes, seconds = divmod(remainder, 60)
+                display_values.append(f"{hours:02d}:{minutes:02d}:{seconds:02d}")
+
+        seconds_series = pd.Series(
+            [pd.NA if value is None else int(value) for value in seconds_values],
+            dtype="Int64",
+        )
+
+        seconds_col = f"{col}{duration_seconds_suffix}"
+        duration_seconds_values[seconds_col] = list(seconds_series)
+        duration_display_values[col] = display_values
+
+        df[col] = display_values
+        df[seconds_col] = seconds_series
+
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
 
     if not HAS_OPENPYXL:
@@ -679,7 +723,8 @@ def main():
 
         last_data_row = len(df) + 1
         date_number_format = "yyyy-mm-dd hh:mm:ss"
-        duration_number_format = "[h]:mm:ss"
+        duration_number_format = "@"
+        seconds_number_format = "0"
 
         for col_name in datetime_columns:
             col_idx = df.columns.get_loc(col_name) + 1
@@ -690,8 +735,32 @@ def main():
         for col_name in duration_columns:
             col_idx = df.columns.get_loc(col_name) + 1
             col_letter = get_column_letter(col_idx)
+            display_values = duration_display_values.get(col_name, [])
             for row_idx in range(data_row_start, last_data_row + 1):
-                ws[f"{col_letter}{row_idx}"].number_format = duration_number_format
+                cell = ws[f"{col_letter}{row_idx}"]
+                if (row_idx - data_row_start) < len(display_values):
+                    value = display_values[row_idx - data_row_start]
+                    cell.value = value or ""
+                else:
+                    cell.value = None
+                cell.number_format = duration_number_format
+
+        for col_name, seconds_values in duration_seconds_values.items():
+            if col_name not in df.columns:
+                continue
+            col_idx = df.columns.get_loc(col_name) + 1
+            col_letter = get_column_letter(col_idx)
+            for row_idx in range(data_row_start, last_data_row + 1):
+                cell = ws[f"{col_letter}{row_idx}"]
+                if (row_idx - data_row_start) < len(seconds_values):
+                    seconds_value = seconds_values[row_idx - data_row_start]
+                    if pd.isna(seconds_value):
+                        cell.value = None
+                    else:
+                        cell.value = int(seconds_value)
+                else:
+                    cell.value = None
+                cell.number_format = seconds_number_format
 
         priority_formula = '"' + ",".join(PRIORITY_OPTIONS) + '"'
         dv_priority = DataValidation(type="list", formula1=priority_formula, allow_blank=True)


### PR DESCRIPTION
## Summary
- convert the duration columns to HH:MM:SS text strings while also filling parallel Int64 seconds columns for Power BI consumption
- update the Excel writer to treat the duration cells as text and keep integer formatting on the seconds columns
- adjust the regression test to assert the new text-based durations and verify the exported totals in seconds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc17ebf2a08320b2835fbba9d7d7c7