### PR TITLE
Fix Excel duration export to preserve total hours

### DIFF
--- a/tests/test_excel_columns.py
+++ b/tests/test_excel_columns.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime, timedelta
 from pathlib import Path
 import sys
 
@@ -264,13 +264,13 @@ def test_dates_and_durations_are_written_with_native_types(tmp_path, monkeypatch
     assert creation_cell.number_format == "yyyy-mm-dd hh:mm:ss"
     assert last_response_cell.number_format == "yyyy-mm-dd hh:mm:ss"
 
-    assert isinstance(wait_cell.value, time)
-    assert isinstance(open_cell.value, time)
-    assert wait_cell.number_format == "hh:mm:ss"
-    assert open_cell.number_format == "hh:mm:ss"
+    assert isinstance(wait_cell.value, timedelta)
+    assert isinstance(open_cell.value, timedelta)
+    assert wait_cell.number_format == "[h]:mm:ss"
+    assert open_cell.number_format == "[h]:mm:ss"
 
-    assert wait_cell.value.strftime("%H:%M:%S") == "02:30:00"
-    assert open_cell.value.strftime("%H:%M:%S") == "04:00:00"
+    assert wait_cell.value == timedelta(hours=2, minutes=30)
+    assert open_cell.value == timedelta(hours=28)
     assert "1899" not in str(wait_cell.value)
     assert "1899" not in str(open_cell.value)
     assert "/" not in wait_cell.number_format

--- a/tickets_parser.py
+++ b/tickets_parser.py
@@ -651,7 +651,7 @@ def main():
         if col in df.columns
     ]
 
-    def timedelta_to_time(value):
+    def timedelta_to_excel_time(value):
         if pd.isna(value):
             return None
         if isinstance(value, pd.Timedelta):
@@ -660,19 +660,12 @@ def main():
             delta = value
         else:
             return None
-        if delta < timedelta(0):
+        if delta <= timedelta(0):
             return None
-        total_seconds = delta.days * 86400 + delta.seconds
-        microseconds = delta.microseconds
-        hours = total_seconds // 3600
-        minutes = (total_seconds % 3600) // 60
-        seconds = total_seconds % 60
-        if hours >= 24:
-            hours = hours % 24
-        return dt_time(hour=hours, minute=minutes, second=seconds, microsecond=microseconds)
+        return delta.total_seconds() / 86400
 
     duration_time_values = {
-        col: [timedelta_to_time(value) for value in df[col]]
+        col: [timedelta_to_excel_time(value) for value in df[col]]
         for col in duration_columns
     }
 
@@ -704,7 +697,7 @@ def main():
 
         last_data_row = len(df) + 1
         date_number_format = "yyyy-mm-dd hh:mm:ss"
-        duration_number_format = "hh:mm:ss"
+        duration_number_format = "[h]:mm:ss"
 
         for col_name in datetime_columns:
             col_idx = df.columns.get_loc(col_name) + 1
@@ -718,7 +711,9 @@ def main():
             time_values = duration_time_values.get(col_name, [])
             for row_idx in range(data_row_start, last_data_row + 1):
                 if (row_idx - data_row_start) < len(time_values):
-                    ws[f"{col_letter}{row_idx}"].value = time_values[row_idx - data_row_start]
+                    excel_value = time_values[row_idx - data_row_start]
+                    if excel_value is not None:
+                        ws[f"{col_letter}{row_idx}"].value = excel_value
                 ws[f"{col_letter}{row_idx}"].number_format = duration_number_format
 
         priority_formula = '"' + ",".join(PRIORITY_OPTIONS) + '"'


### PR DESCRIPTION
## Summary
- convert duration columns to Excel serial time values so multi-day waits no longer wrap at 24 hours
- format duration cells with [h]:mm:ss and adjust tests to cover the new representation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc44ee57dc8320b95e3cbf0fc60b30