### PR TITLE
Format duration columns with day component

### DIFF
--- a/tests/test_excel_columns.py
+++ b/tests/test_excel_columns.py
@@ -269,8 +269,8 @@ def test_dates_are_native_and_durations_are_text(tmp_path, monkeypatch):
     assert wait_cell.number_format == "@"
     assert open_cell.number_format == "@"
 
-    assert wait_cell.value == "02:30:00"
-    assert open_cell.value == "28:00:00"
+    assert wait_cell.value == "0.02:30:00"
+    assert open_cell.value == "1.04:00:00"
 
     workbook.close()
 
@@ -384,6 +384,6 @@ def test_existing_duration_values_are_preserved_and_normalized(tmp_path, monkeyp
 
     workbook.close()
 
-    assert results["123"] == ("448:00:00", "@", "123:00:00", "@")
-    assert results["456"] == ("36:00:00", "@", "10:00:00", "@")
+    assert results["123"] == ("18.16:00:00", "@", "5.03:00:00", "@")
+    assert results["456"] == ("1.12:00:00", "@", "0.10:00:00", "@")
     assert "789" in results

--- a/tickets_parser.py
+++ b/tickets_parser.py
@@ -673,10 +673,14 @@ def main():
     def format_total_seconds(total_seconds: Optional[int]) -> Optional[str]:
         if total_seconds is None or total_seconds <= 0:
             return None
-        hours, remainder = divmod(total_seconds, 3600)
+        days, remainder = divmod(total_seconds, 86400)
+        hours, remainder = divmod(remainder, 3600)
         minutes, seconds = divmod(remainder, 60)
-        hours_str = str(hours).zfill(2)
-        return f"{hours_str}:{minutes:02d}:{seconds:02d}"
+        return f"{days}.{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+    days_hours_pattern = re.compile(
+        r"^(?P<days>\d+)\.(?P<hours>\d{2}):(?P<minutes>\d{2}):(?P<seconds>\d{2})$"
+    )
 
     def timedelta_to_text(value):
         if value is None:
@@ -720,6 +724,16 @@ def main():
             lower = text.lower()
             if lower in {"nat", "nan"}:
                 return None
+            match = days_hours_pattern.match(text)
+            if match:
+                days = int(match.group("days"))
+                hours = int(match.group("hours"))
+                minutes = int(match.group("minutes"))
+                seconds = int(match.group("seconds"))
+                total_seconds = (
+                    days * 86400 + hours * 3600 + minutes * 60 + seconds
+                )
+                return format_total_seconds(total_seconds)
             parts = [part.strip() for part in text.split(":")]
             if 2 <= len(parts) <= 3 and all(part.isdigit() for part in parts):
                 hours = int(parts[0])


### PR DESCRIPTION
## Summary
- format duration outputs as days.hours:minutes:seconds and normalize existing values
- update duration parsing to understand the new textual format
- align duration-related tests with the new representation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc66412fac8320be018a416deb18af